### PR TITLE
Send logs to stderr, not stdout

### DIFF
--- a/src/logging.ml
+++ b/src/logging.ml
@@ -3,7 +3,7 @@ let reporter =
     let k _ = over (); k () in
     let src = Logs.Src.name src in
     msgf @@ fun ?header ?tags:_ fmt ->
-    Fmt.kpf k Fmt.stdout ("%a %a @[" ^^ fmt ^^ "@]@.")
+    Fmt.kpf k Fmt.stderr ("%a %a @[" ^^ fmt ^^ "@]@.")
       Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
       Logs_fmt.pp_header (level, header)
   in


### PR DESCRIPTION
Sometimes it's useful for a pipeline to produce actual output on stdout.